### PR TITLE
Fixed #31

### DIFF
--- a/src/CharSetView.cpp
+++ b/src/CharSetView.cpp
@@ -58,7 +58,7 @@ void CharSetView::Draw(BRect urect)
 
 	if (drawmode) {
 		float fh = (colwidth > rowheight) ? rowheight : colwidth;
-		font.SetSize(fh * 0.8);
+		font.SetSize(fh * 0.6);
 		font.GetHeight(&fheight);
 		SetFont(&font);
 

--- a/src/CharView.cpp
+++ b/src/CharView.cpp
@@ -47,7 +47,7 @@ void CharView::Draw(BRect urect)
 	SetHighColor(displayColor);
 
 	if (drawmode) {
-		font.SetSize(urect.Width() * 0.8);
+		font.SetSize(urect.Width() * 0.6);
 		font.GetHeight(&fheight);
 
 		//  Unicode to UTF8 Character encoding


### PR DESCRIPTION
Changes font scaling to fit parent object.
![deepinscreenshot_select-area_20180102133155](https://user-images.githubusercontent.com/19305859/34476273-e32b351c-efc1-11e7-95cd-61a9a1b8feb7.png)
